### PR TITLE
fix(doc): make doc tests compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,9 +2997,11 @@ dependencies = [
  "color_quant",
  "crossterm 0.29.0",
  "fast_image_resize",
+ "ffmpeg-sidecar",
  "flate2",
  "image",
  "lazy_static",
+ "rand 0.9.1",
  "signal-hook",
  "windows",
 ]

--- a/crates/markdownify/src/lib.rs
+++ b/crates/markdownify/src/lib.rs
@@ -15,18 +15,28 @@ use zip::ZipArchive;
 /// convert `any` document into markdown
 /// # example:
 /// ```
+/// use std::path::Path;
+/// use markdownify::convert;
+///
 /// let path = Path::new("path/to/file.docx");
-/// let md = convert(&path, None).unwrap();
-/// println!("{}", md);
+/// match convert(&path, None) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 ///
 /// # with name:
 ///
 /// ```
+/// use std::path::Path;
+/// use markdownify::convert;
+///
 /// let path = Path::new("path/to/file.docx");
-/// let name = "file.docx".to_string()
-/// let md = convert(&path, Some(&name)).unwrap();
-/// println!("{}", md);
+/// let name = "file.docx".to_string();
+/// match convert(&path, Some(&name)) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn convert(
     path: &Path,
@@ -69,11 +79,16 @@ pub fn convert(
 }
 
 /// convert `zip` into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::zip_convert;
+///
 /// let path = Path::new("path/to/archive.zip");
-/// let md = zip_convert(&path).unwrap();
-/// println!("{}", md);
+/// match zip_convert(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn zip_convert(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let file = File::open(path)?;

--- a/crates/markdownify/src/opendoc.rs
+++ b/crates/markdownify/src/opendoc.rs
@@ -7,11 +7,16 @@ use zip::ZipArchive;
 use super::sheets;
 
 /// convert `odt` and `odp` files into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::opendoc::opendoc_convert;
+///
 /// let path = Path::new("path/to/file.odt");
-/// let md = opendoc_convert(&path).unwrap();
-/// println!("{}", md);
+/// match opendoc_convert(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn opendoc_convert(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let data = std::fs::read(path)?;

--- a/crates/markdownify/src/pdf.rs
+++ b/crates/markdownify/src/pdf.rs
@@ -396,7 +396,7 @@ impl StyledText {
 
         let items = StyledText::extract_tables(items);
         let mut rows: Vec<Vec<&StyledText>> = Vec::new();
-        // for figuring out a fair gap (so we can have better seperated paragraphs)
+        // for figuring out a fair gap (so we can have better separated paragraphs)
         let mut heights: Vec<f32> = Vec::new();
 
         //grouping into rows of within +-3 y
@@ -478,11 +478,16 @@ fn compute_pdf_position(
 }
 
 /// convert `pdf` into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::pdf::pdf_convert;
+///
 /// let path = Path::new("path/to/file.pdf");
-/// let md = pdf_convert(&path).unwrap();
-/// println!("{}", md);
+/// match pdf_convert(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn pdf_convert(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let doc = lopdf::Document::load(path)?;

--- a/crates/markdownify/src/pptx.rs
+++ b/crates/markdownify/src/pptx.rs
@@ -10,11 +10,16 @@ use zip::ZipArchive;
 use super::sheets;
 
 /// convert `pptx` files into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::pptx::pptx_converter;
+///
 /// let path = Path::new("path/to/file.pptx");
-/// let md = pptx_converter(&path).unwrap();
-/// println!("{}", md);
+/// match pptx_converter(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn pptx_converter(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let data = fs::read(path)?;

--- a/crates/markdownify/src/sheets.rs
+++ b/crates/markdownify/src/sheets.rs
@@ -17,10 +17,12 @@ fn detect_delimiter(line: &str) -> u8 {
 }
 
 /// creates a markdown table
-/// # usuage:
+/// # usage:
 /// ```
+/// use markdownify::sheets::to_markdown_table;
+///
 /// let headers = vec!["Names".to_string(), "Salary".to_string()];
-/// let row = vec![
+/// let rows = vec![
 ///     vec!["Sarah".to_string(), "100".to_string()],
 ///     vec!["Jeff".to_string(), "200".to_string()],
 /// ];
@@ -40,11 +42,16 @@ pub fn to_markdown_table(headers: &[String], rows: &[Vec<String>]) -> String {
 }
 
 /// convert `xlsx` | `xls` | `xlsm` | `xlsb` | `xla` | `xlam` | `ods` files into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::sheets::sheets_convert;
+///
 /// let path = Path::new("path/to/file.xlsx");
-/// let md = sheets_convert(&path).unwrap();
-/// println!("{}", md);
+/// match sheets_convert(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn sheets_convert(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let mut workbook = calamine::open_workbook_auto(path)?;
@@ -77,11 +84,16 @@ pub fn sheets_convert(path: &Path) -> Result<String, Box<dyn std::error::Error>>
 }
 
 /// convert `csv` into markdown
-/// # usuage:
+/// # usage:
 /// ```
+/// use std::path::Path;
+/// use markdownify::sheets::csv_converter;
+///
 /// let path = Path::new("path/to/file.csv");
-/// let md = csv_converter(&path).unwrap();
-/// println!("{}", md);
+/// match csv_converter(&path) {
+///     Ok(md) => println!("{}", md),
+///     Err(e) => eprintln!("Error: {}", e)
+/// }
 /// ```
 pub fn csv_converter(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     let mut file = File::open(path)?;

--- a/crates/rasteroid/Cargo.toml
+++ b/crates/rasteroid/Cargo.toml
@@ -22,3 +22,7 @@ base64 = "0.22.1"
 fast_image_resize = { version = "5.1.2", features = ["image"] }
 flate2 = "1.1.0"
 signal-hook = "0.3.17"
+
+[dev-dependencies]
+ffmpeg-sidecar = "2.0.5"
+rand = "0.9.1"

--- a/crates/rasteroid/src/image_extended.rs
+++ b/crates/rasteroid/src/image_extended.rs
@@ -1,8 +1,8 @@
 use std::{error, io::Cursor};
 
-use fast_image_resize::{IntoImageView, Resizer, images::Image};
+use fast_image_resize::{images::Image, IntoImageView, Resizer};
 use image::{
-    DynamicImage, GenericImageView, ImageEncoder, codecs::png::PngEncoder, imageops::crop_imm,
+    codecs::png::PngEncoder, imageops::crop_imm, DynamicImage, GenericImageView, ImageEncoder,
 };
 
 use super::term_misc::{self, dim_to_px};
@@ -11,9 +11,15 @@ pub trait InlineImage {
     /// fast image resizer, that takes logic units.
     /// # example:
     /// ```
+    /// use std::path::Path;
+    /// use rasteroid::image_extended::InlineImage;
+    ///
     /// let path = Path::new("image.png");
-    /// let buf = std::fs::read(path).unwrap();
-    /// let dyn_img = image::load_from_memory(&image).unwrap();
+    /// let buf = match std::fs::read(path) {
+    ///     Ok(buf) => buf,
+    ///     Err(e) => return,
+    /// };
+    /// let dyn_img = image::load_from_memory(&buf).unwrap();
     /// let (img_data, offset) = dyn_img.resize_plus(Some("80%"),Some("200c")).unwrap();
     /// ```
     /// * the offset is for centering the image
@@ -26,10 +32,16 @@ pub trait InlineImage {
     /// zoom into the image, and move around
     /// # example:
     /// ```
+    /// use std::path::Path;
+    /// use rasteroid::image_extended::InlineImage;
+    ///
     /// let path = Path::new("image.png");
-    /// let buf = std::fs::read(path).unwrap();
-    /// let dyn_img = image::load_from_memory(&image).unwrap();
-    /// let dyn_img = dyn_img.zoom_pan(Some(5), Some(3), Some(2))
+    /// let buf = match std::fs::read(path) {
+    ///     Ok(buf) => buf,
+    ///     Err(e) => return,
+    /// };
+    /// let dyn_img = image::load_from_memory(&buf).unwrap();
+    /// let dyn_img = dyn_img.zoom_pan(Some(5), Some(3), Some(2));
     /// ```
     /// the above zooms 50%, moves right 15% and down 10%
     fn zoom_pan(self, zoom: Option<usize>, x: Option<i32>, y: Option<i32>) -> Self;
@@ -114,6 +126,8 @@ impl InlineImage for DynamicImage {
 /// calculates the dimensions of an image into fit bounding box
 /// # example:
 /// ```
+/// use rasteroid::image_extended::calc_fit;
+///
 /// let (new_width, new_height) = calc_fit(1920, 1080, 800, 400);
 /// ```
 /// the above will return dimensions close to 800x400 that maintain the aspect ratio of 1920x1080

--- a/crates/rasteroid/src/iterm_encoder.rs
+++ b/crates/rasteroid/src/iterm_encoder.rs
@@ -5,8 +5,17 @@ use std::io::Write;
 /// should work with all formats Iterm, which include but not limited to GIF,PNG,JPEG..
 /// # example:
 /// ```
+/// use std::path::Path;
+/// use rasteroid::InlineEncoder;
+/// use rasteroid::inline_an_image;
+/// use rasteroid::iterm_encoder::encode_image;
+/// use std::io::Write;
+///
 /// let path = Path::new("image.png");
-/// let bytes = std::fs::read(path).unwrap();
+/// let bytes = match std::fs::read(path) {
+///     Ok(bytes) => bytes,
+///     Err(e) => return,
+/// };
 /// let mut stdout = std::io::stdout();
 /// encode_image(&bytes, &stdout, None).unwrap();
 /// stdout.flush().unwrap();
@@ -34,6 +43,8 @@ pub fn encode_image(
 /// checks if the current terminal supports Iterm graphic protocol
 /// # example:
 /// ```
+///  use rasteroid::iterm_encoder::is_iterm_capable;
+///
 /// let env = rasteroid::term_misc::EnvIdentifiers::new();
 /// let is_capable = is_iterm_capable(&env);
 /// println!("Iterm: {}", is_capable);

--- a/crates/rasteroid/src/lib.rs
+++ b/crates/rasteroid/src/lib.rs
@@ -12,11 +12,19 @@ extern crate lazy_static;
 /// encode an image bytes into inline image using the given encoder
 /// # example:
 /// ```
+/// use std::path::Path;
+/// use rasteroid::InlineEncoder;
+/// use rasteroid::inline_an_image;
+/// use std::io::Write;
+///
 /// let path = Path::new("image.png");
-/// let bytes = std::fs::read(path).unwrap();
+/// let bytes = match std::fs::read(path) {
+///     Ok(bytes) => bytes,
+///     Err(e) => return,
+/// };
 /// let mut stdout = std::io::stdout();
 /// let encoder = InlineEncoder::auto_detect(true, false, false); // force kitty as fallback
-/// inline_an_image(&bytes, &stdout, None, encoder).unwrap();
+/// inline_an_image(&bytes, &stdout, None, &encoder).unwrap();
 /// stdout.flush().unwrap();
 /// ```
 /// MENTION: it should work for Iterm Gifs too.

--- a/crates/rasteroid/src/sixel_encoder.rs
+++ b/crates/rasteroid/src/sixel_encoder.rs
@@ -1,4 +1,4 @@
-use crate::term_misc::{EnvIdentifiers, offset_to_terminal};
+use crate::term_misc::{offset_to_terminal, EnvIdentifiers};
 use color_quant::NeuQuant;
 use image::{ImageBuffer, Rgb};
 use std::{
@@ -12,8 +12,15 @@ const SIXEL_MIN: u8 = 0x3f; // '?'
 /// works with all the formats that the image crate supports
 /// # example:
 /// ```
+/// use std::path::Path;
+/// use std::io::Write;
+/// use rasteroid::sixel_encoder::encode_image;
+///
 /// let path = Path::new("image.png");
-/// let bytes = std::fs::read(path).unwrap();
+/// let bytes = match std::fs::read(path) {
+///     Ok(bytes) => bytes,
+///     Err(e) => return,
+/// };
 /// let mut stdout = std::io::stdout();
 /// encode_image(&bytes, &stdout, None).unwrap();
 /// stdout.flush().unwrap();
@@ -38,6 +45,8 @@ pub fn encode_image(
 /// checks if the current terminal supports Sixel's graphic protocol
 /// # example:
 /// ```
+/// use rasteroid::sixel_encoder::is_sixel_capable;
+///
 /// let env = rasteroid::term_misc::EnvIdentifiers::new();
 /// let is_capable = is_sixel_capable(&env);
 /// println!("Sixel: {}", is_capable);

--- a/crates/rasteroid/src/term_misc.rs
+++ b/crates/rasteroid/src/term_misc.rs
@@ -1,10 +1,10 @@
 use std::{
     collections::HashMap,
     env, f32,
-    sync::{Arc, OnceLock, atomic::AtomicBool},
+    sync::{atomic::AtomicBool, Arc, OnceLock},
 };
 
-use base64::{Engine, engine::general_purpose};
+use base64::{engine::general_purpose, Engine};
 use crossterm::terminal::{size, window_size};
 use signal_hook::consts::signal::*;
 use signal_hook::flag;
@@ -37,7 +37,7 @@ lazy_static! {
 pub struct Size {
     pub width: u16,
     pub height: u16,
-    force: bool,
+    pub force: bool,
 }
 
 impl Winsize {
@@ -80,9 +80,12 @@ impl Winsize {
 }
 
 /// setting a fallback for when fails to query spx and sc.
-/// scale is for scaling while maintaing center. (scale the box not the image)
+/// scale is for scaling while maintaining center. (scale the box not the image)
 /// # example:
 /// ```
+/// use rasteroid::term_misc::init_winsize;
+/// use rasteroid::term_misc::Size;
+///
 /// let spx = Size {
 ///     width: 1920,  // width in pixels
 ///     height: 1080, // height in pixels
@@ -178,7 +181,7 @@ pub fn dim_to_px(dim: &str, direction: SizeDirection) -> Result<u32, String> {
 #[cfg(windows)]
 fn get_size_windows() -> Option<(u16, u16)> {
     use windows::Win32::UI::WindowsAndMessaging::{
-        AdjustWindowRect, GWL_STYLE, GetWindowLongW, WINDOW_STYLE,
+        AdjustWindowRect, GetWindowLongW, GWL_STYLE, WINDOW_STYLE,
     };
     use windows::Win32::{
         Foundation::{HWND, RECT},
@@ -275,7 +278,7 @@ pub fn break_size_string(s: &str) -> Result<Size, Box<dyn std::error::Error>> {
     })
 }
 
-/// get a handle to when the program is killed (will overide so kill the program shortly after)
+/// get a handle to when the program is killed (will override so kill the program shortly after)
 pub fn setup_signal_handler() -> Arc<AtomicBool> {
     let shutdown = Arc::new(AtomicBool::new(false));
 


### PR DESCRIPTION
Hi =)

Just spent some time making your doc tests compile. You can test it with `cargo test --doc`.

Most of the time it was just missing some imports.
I kept it as example code so when it was panicking due to files not present on the system, I just cheated by adding some matches on Result types to avoid panics:

```diff
- /// let md = opendoc_convert(&path).unwrap();
- /// println!("{}", md);
+ /// match opendoc_convert(&path) {
+ ///     Ok(md) => println!("{}", md),
+ ///     Err(e) => eprintln!("Error: {}", e),
+ /// }
```

Rust documentation's code blocks are used as [documentation tests](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html) so they are supposed to compile correctly.

When packaging Rust projects for nixpkgs (#3), we also run documentation tests.