### PR TITLE
feat: support local images in md

### DIFF
--- a/crates/core/src/catter.rs
+++ b/crates/core/src/catter.rs
@@ -220,7 +220,7 @@ pub fn cat(
             let is_tty = stdout().is_tty();
             let use_color = opts.color.should_use(is_tty);
             let content = match use_color {
-                true => markdown_viewer::md_to_ansi(&res, &opts),
+                true => markdown_viewer::md_to_ansi(&res, &opts, Some(path)),
                 false => res,
             };
             let use_pager = opts.paging.should_use(is_tty && content.lines().count() > term_misc::get_wininfo().sc_height as usize);

--- a/crates/core/src/markdown_viewer/mod.rs
+++ b/crates/core/src/markdown_viewer/mod.rs
@@ -15,9 +15,10 @@ use syntect::{highlighting::ThemeSet, parsing::SyntaxSet};
 use themes::CustomTheme;
 use utils::limit_newlines;
 
+use std::path::Path;
 use crate::{UnwrapOrExit, config::McatConfig};
 
-pub fn md_to_ansi(md: &str, config: &McatConfig) -> String {
+pub fn md_to_ansi(md: &str, config: &McatConfig, markdown_file_path: Option<&Path>) -> String {
     let res = &html_preprocessor::process(md);
     let md = &res.content;
 
@@ -36,7 +37,7 @@ pub fn md_to_ansi(md: &str, config: &McatConfig) -> String {
 
     let ps = SyntaxSet::load_defaults_newlines();
     let theme = CustomTheme::from(config.theme.as_ref());
-    let image_preprocessor = ImagePreprocessor::new(root, config);
+    let image_preprocessor = ImagePreprocessor::new(root, config, markdown_file_path);
     let mut ctx = AnsiContext {
         ps,
         theme,


### PR DESCRIPTION
Support rendering local images in markdown files. Supports absolute paths and relative paths (both relative to the cwd and the markdown file itself)