### PR TITLE
Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ follow the instructions at the [latest release](https://github.com/Skardyy/mcat/
    <summary>Homebrew (MacOS/Linux)</summary>
 
 ```sh
-brew install Skardyy/mcat/mcat
+brew install mcat
 ```
 </details>
 <details>


### PR DESCRIPTION
Mcat is now [available](https://github.com/Homebrew/homebrew-core/commit/0b64dae8bfc8f36d2cfbb13c765dc831147479f4) via the official Core repository.