### PR TITLE
using internal lzma to avoid macos crash in signed builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+dependencies = [
+ "sha2",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,10 +1800,10 @@ dependencies = [
  "calamine",
  "csv",
  "flate2",
+ "lzma-rust2",
  "quick-xml 0.39.0",
  "tar",
  "thiserror 2.0.18",
- "xz2",
  "zip 8.1.0",
 ]
 
@@ -2831,6 +2840,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ thiserror = "2.0.18"
 zip = { version = "8.1.0", features = [ "deflate-flate2" ], default-features = false }
 tar = "0.4.44"
 flate2 = "1.1.9"
-xz2 = "0.1.7"
+lzma-rust2 = { version = "0.16.2", default-features = false, features = ["std", "xz"] }
 calamine = "0.33.0"
 csv = "1.4.0"
 quick-xml = "0.39.0"

--- a/crates/markdownify/Cargo.toml
+++ b/crates/markdownify/Cargo.toml
@@ -19,7 +19,7 @@ zip.workspace = true
 tar.workspace = true
 
 flate2.workspace = true
-xz2.workspace = true
+lzma-rust2.workspace = true
 
 calamine.workspace = true
 csv.workspace = true

--- a/crates/markdownify/src/lib.rs
+++ b/crates/markdownify/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use flate2::read::GzDecoder;
-use xz2::read::XzDecoder;
+use lzma_rust2::XzReader;
 
 use crate::{archives::FileTree, error::ParsingError};
 
@@ -152,7 +152,7 @@ pub fn convert(path: &Path) -> Result<String, ParsingError> {
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_lowercase();
-            XzDecoder::new(file)
+            XzReader::new(file, true)
                 .read_to_end(&mut content)
                 .map_err(ParsingError::UnreadableFile)?;
         }


### PR DESCRIPTION
When building a release build with MacOS (Signed and notarized), my app crashes with the following crash log:

```
dyld[38391]: Library not loaded: /opt/homebrew/opt/xz/lib/liblzma.5.dylib
  Referenced from: <C6010F46-8EAA-3461-850F-8E0FC08FA1EB> /Applications/ISA Warden.app/Contents/MacOS/isa-warden
  Reason: tried: '/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (code signature in <7E7BEF36-1537-3B34-91B7-ECA90293BA43> '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (no such file), '/opt/homebrew/opt/xz/lib/liblzma.5.dylib' (code signature in <7E7BEF36-1537-3B34-91B7-ECA90293BA43> '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' (code signature in <7E7BEF36-1537-3B34-91B7-ECA90293BA43> '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' (no such file), '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' (code signature in <7E7BEF36-1537-3B34-91B7-ECA90293BA43> '/opt/homebrew/Cellar/xz/5.8.2/lib/liblzma.5.dylib' not valid for use in process: mapping process and mapped file (non-platform) have different Team IDs)
```

We narrowed it down to the way LZMA is used. The binary tries to load liblzma installed using Brew, but MacOS forces to have the same signature as the app you are using. By putting LZMA in pure-rust, it is no longer becoming an issue since LZMA is now embedded in the binary.