### PR TITLE
fix(markdown_viewer): add block spacing between children in list items

### DIFF
--- a/crates/core/src/markdown_viewer/mod.rs
+++ b/crates/core/src/markdown_viewer/mod.rs
@@ -134,3 +134,37 @@ fn comrak_options<'a>() -> options::Options<'a> {
 
     options
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::McatConfig;
+
+    fn render(md: &str) -> String {
+        let config = McatConfig::default();
+        let result = md_to_ansi(md, &config, None);
+        strip_ansi_escapes::strip_str(&result).to_string()
+    }
+
+    #[test]
+    fn list_item_with_code_block_on_separate_lines() {
+        let md = "1. Step one:\n\n        echo hello\n";
+        let output = render(md);
+
+        // The code block header (file icon + "text") must not appear on the
+        // same line as the list item text. Before the fix, collect() joined
+        // block-level children with no separator, so "Step one:" and the code
+        // block header ended up on one line.
+        let step_line = output.lines().find(|l| l.contains("Step one"));
+        assert!(step_line.is_some(), "should contain \'Step one\'");
+        let step_line = step_line.unwrap();
+
+        // \u{f15c} is the file icon used in code block headers
+        assert!(
+            !step_line.contains("\u{f15c}") && !step_line.contains("text"),
+            "code block header should not be on the same line as list item text, got: {:?}",
+            step_line,
+        );
+    }
+}

--- a/crates/core/src/markdown_viewer/render.rs
+++ b/crates/core/src/markdown_viewer/render.rs
@@ -231,7 +231,7 @@ fn render_item<'a>(node: &'a AstNode<'a>, ctx: &mut AnsiContext) -> String {
     };
 
     let yellow = ctx.theme.yellow.fg.clone();
-    let content = collect(node, ctx, "");
+    let content = collect(node, ctx, "\n\n");
     let content = content.trim();
     let depth = ctx.list_depth - 1;
 
@@ -250,7 +250,7 @@ fn render_task_item<'a>(node: &'a AstNode<'a>, ctx: &mut AnsiContext) -> String 
     };
 
     let offset = " ".repeat(node.data.borrow().sourcepos.start.column - 1);
-    let content = collect(node, ctx, "");
+    let content = collect(node, ctx, "\n\n");
     let content = content.trim();
     let (icon, colour) = match task.symbol.map(|c| c.to_ascii_lowercase()) {
         Some('x') => ("󰱒", &ctx.theme.green.fg),


### PR DESCRIPTION
**Bug:** Code blocks inside list items unexpectedly start on the same line as the list-item text — rather than on a new, separate line.

**Cause:** Commit c8b0be1 refactored newline handling so that block elements no longer add their own `\n\n` wrappers — relying instead on a separator passed to `collect()`. But `render_item` and `render_task_item` were given an empty separator, so block-level children (e.g., a paragraph followed by a code block) got concatenated onto the same line.

**Fix:** Change the separator from `""` to `"\n\n"` in `render_item` and `render_task_item` — so that block-level children within list items get proper spacing.

---

Minimal repro to test with:

```markdown
1. Set the environment variable:

        export FOO=bar

2. Run the script:

        python ./build.py all

3. Check the output.
```

Rendered output without the fix in this PR:

<img width="400" height="173" alt="image" src="https://github.com/user-attachments/assets/89c53a67-5568-4785-a275-0066001d2ab2" />

With the fix in this PR:

<img width="400" height="259" alt="image" src="https://github.com/user-attachments/assets/6bfbe954-f3c0-49ee-851d-878b4e2601d3" />
