### PR TITLE
fix(html_preprocessor): render HTML tags in backticks literally

### DIFF
--- a/crates/core/src/markdown_viewer/html_preprocessor.rs
+++ b/crates/core/src/markdown_viewer/html_preprocessor.rs
@@ -240,11 +240,86 @@ impl ProcessingContext {
     }
 }
 
+/// Replace backtick-enclosed code spans with placeholders.
+/// Handles both single and multiple backtick delimiters.
+fn protect_code_spans(input: &str) -> (String, Vec<String>) {
+    let mut result = String::with_capacity(input.len());
+    let mut placeholders: Vec<String> = Vec::new();
+    let chars: Vec<char> = input.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '`' {
+            // Count consecutive backticks
+            let start = i;
+            let mut tick_count = 0;
+            while i < chars.len() && chars[i] == '`' {
+                tick_count += 1;
+                i += 1;
+            }
+            // Find the matching closing backticks
+            let mut found_end = false;
+            let mut j = i;
+            while j <= chars.len().saturating_sub(tick_count) {
+                let mut matches = true;
+                for k in 0..tick_count {
+                    if chars[j + k] != '`' {
+                        matches = false;
+                        break;
+                    }
+                }
+                if matches {
+                    // Verify the closing delimiter is exactly
+                    // tick_count backticks (not more)
+                    let after = j + tick_count;
+                    if after >= chars.len() || chars[after] != '`' {
+                        let end = j + tick_count;
+                        let span: String = chars[start..end]
+                            .iter().collect();
+                        let idx = placeholders.len();
+                        placeholders.push(span);
+                        result.push_str(
+                            &format!("MCAT_CODE_PLACEHOLDER_{}_END", idx),
+                        );
+                        i = end;
+                        found_end = true;
+                        break;
+                    }
+                }
+                j += 1;
+            }
+            if !found_end {
+                // No matching close; emit the backticks literally
+                for _ in 0..tick_count {
+                    result.push('`');
+                }
+            }
+        } else {
+            result.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    (result, placeholders)
+}
+
 pub fn process(markdown: &str) -> String {
     let ctx = ProcessingContext::new();
 
-    let escaped_markdown = ctx.escape_unknown_elements(markdown);
-    let document = Html::parse_fragment(&escaped_markdown);
+    // Protect backtick-enclosed content from HTML processing.
+    // Replace inline code spans with placeholders so the HTML
+    // parser does not interpret tags inside backticks.
+    let (protected, placeholders) = protect_code_spans(markdown);
 
-    collect(document.root_element(), &ctx, "\n\n")
+    let escaped_markdown = ctx.escape_unknown_elements(&protected);
+    let document = Html::parse_fragment(&escaped_markdown);
+    let mut content = collect(document.root_element(), &ctx, "\n\n");
+
+    // Restore backtick-enclosed content
+    for (i, original) in placeholders.iter().enumerate() {
+        let placeholder = format!("MCAT_CODE_PLACEHOLDER_{}_END", i);
+        content = content.replace(&placeholder, original);
+    }
+
+    content
 }

--- a/crates/core/src/markdown_viewer/mod.rs
+++ b/crates/core/src/markdown_viewer/mod.rs
@@ -146,3 +146,62 @@ fn comrak_options<'a>() -> options::Options<'a> {
 
     options
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::McatConfig;
+
+    fn render(md: &str) -> String {
+        use clap::Parser;
+        let mut config = McatConfig::parse_from(["mcat", "-"]);
+        config.finalize().unwrap();
+        let result = md_to_ansi(md, config, None).unwrap();
+        strip_ansi_escapes::strip_str(&result).to_string()
+    }
+
+    #[test]
+    fn list_item_with_code_block_on_separate_lines() {
+        let md = "1. Step one:\n\n        echo hello\n";
+        let output = render(md);
+
+        // The code block header (file icon + "text") must not
+        // appear on the same line as the list item text.
+        let step_line = output.lines().find(|l| l.contains("Step one"));
+        assert!(step_line.is_some(), "should contain \'Step one\'");
+        let step_line = step_line.unwrap();
+
+        assert!(
+            !step_line.contains("\u{f15c}") && !step_line.contains("text"),
+            "code block header should not be on the same line as list item text, got: {:?}",
+            step_line,
+        );
+    }
+
+    #[test]
+    fn html_tags_in_backticks_rendered_literally() {
+        let md = "This has `<div>` and `<script>` in backticks.\n";
+        let output = render(md);
+        let lines: Vec<&str> = output.lines()
+            .filter(|l| !l.trim().is_empty())
+            .collect();
+
+        // Should be a single line with tags rendered literally
+        assert_eq!(
+            lines.len(), 1,
+            "should be one line, got {}:\n{}",
+            lines.len(), output,
+        );
+        assert!(
+            lines[0].contains("<div>"),
+            "should contain literal <div>, got: {:?}",
+            lines[0],
+        );
+        assert!(
+            lines[0].contains("<script>"),
+            "should contain literal <script>, got: {:?}",
+            lines[0],
+        );
+    }
+}


### PR DESCRIPTION
**Bug:** HTML tags inside backticks (inline code) like `` `<div>` `` were being processed as actual HTML elements, rather than rendered as literal text.

**Cause:** The HTML preprocessor “escapes” angle brackets to named character references (entities), then looks for known HTML tags in that “escaped” format, and un-escapes the character references back to literal angle brackets, for parsing as HTML. But the code didn’t account for markdown context, so even tags inside backticks end up being parsed as HTML.

**Fix:** Before HTML parsing: pull all backtick-delimited strings out into a collection, and replace each with a custom “placeholder” string that’s essentially a reference to its index in that collection. After HTML parsing: Substitute all our backtick-reference custom “placeholder” strings with the original literal backtick-delimited strings.
