### PR TITLE
fix(interactive): render mermaid diagrams, fix zoom panic, smooth nav

### DIFF
--- a/crates/core/src/image_viewer.rs
+++ b/crates/core/src/image_viewer.rs
@@ -85,7 +85,8 @@ pub fn run_interactive_viewer(
     // Initial callback
     let mut should_quit = callback(&mut viewport, current_image);
     let mut last_callback_time = std::time::Instant::now();
-    let callback_throttle = std::time::Duration::from_millis(50);
+    let callback_throttle = std::time::Duration::from_millis(16);
+    let mut needs_redraw = false;
 
     while should_quit.is_some() {
         if event::poll(Duration::from_millis(16))? {
@@ -277,14 +278,19 @@ pub fn run_interactive_viewer(
                     _ => {}
                 }
 
-                // Callback after each key press, but throttled
+                // Mark redraw as needed and let the render scheduler handle throttling.
                 if clicked_correct_key {
-                    let now = std::time::Instant::now();
-                    if now.duration_since(last_callback_time) >= callback_throttle {
-                        should_quit = callback(&mut viewport, current_image);
-                        last_callback_time = now;
-                    }
+                    needs_redraw = true;
                 }
+            }
+        }
+
+        if needs_redraw {
+            let now = std::time::Instant::now();
+            if now.duration_since(last_callback_time) >= callback_throttle {
+                should_quit = callback(&mut viewport, current_image);
+                last_callback_time = now;
+                needs_redraw = false;
             }
         }
     }

--- a/crates/core/src/markdown_viewer/mod.rs
+++ b/crates/core/src/markdown_viewer/mod.rs
@@ -93,6 +93,8 @@ pub fn md_to_ansi(
 pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
     let options = comrak_options();
 
+    let markdown = preprocess_mermaid_fences(markdown, theme);
+
     let theme = CustomTheme::from(theme);
     let mut theme_set = ThemeSet::load_defaults();
     let mut plugins = options::Plugins::default();
@@ -112,7 +114,7 @@ pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
         false => None,
     };
 
-    let html = markdown_to_html_with_plugins(markdown, &options, &plugins);
+    let html = markdown_to_html_with_plugins(&markdown, &options, &plugins);
     match full_css {
         Some(css) => format!(
             r#"
@@ -131,6 +133,85 @@ pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
         ),
         None => html,
     }
+}
+
+fn preprocess_mermaid_fences(markdown: &str, theme: &Theme) -> String {
+    let mut out = Vec::new();
+    let mut iter = markdown.lines();
+
+    while let Some(line) = iter.next() {
+        if let Some((fence_char, fence_len, lang)) = parse_fence_open(line)
+            && matches!(lang, "mermaid" | "mmd")
+        {
+            let mut body = Vec::new();
+            let mut closed = false;
+
+            for next_line in iter.by_ref() {
+                if is_fence_close(next_line, fence_char, fence_len) {
+                    closed = true;
+                    break;
+                }
+                body.push(next_line);
+            }
+
+            if closed {
+                let source = body.join("\n");
+                if let Some(svg) = render_mermaid_svg(&source, theme) {
+                    out.push("<div class=\"mcat-mermaid\">".to_owned());
+                    out.push(svg);
+                    out.push("</div>".to_owned());
+                    continue;
+                }
+            }
+
+            out.push(line.to_owned());
+            out.extend(body.into_iter().map(ToOwned::to_owned));
+            if closed {
+                out.push(std::iter::repeat_n(fence_char, fence_len).collect());
+            }
+            continue;
+        }
+
+        out.push(line.to_owned());
+    }
+
+    out.join("\n")
+}
+
+fn render_mermaid_svg(source: &str, theme: &Theme) -> Option<String> {
+    let mut opts = mermaid_rs_renderer::RenderOptions::modern();
+    opts.theme = theme.to_custom().to_mermaid_theme();
+    mermaid_rs_renderer::render_with_options(source, opts).ok()
+}
+
+fn parse_fence_open(line: &str) -> Option<(char, usize, &str)> {
+    let trimmed = line.trim_start();
+    let first = trimmed.chars().next()?;
+    if first != '`' && first != '~' {
+        return None;
+    }
+
+    let fence_len = trimmed.chars().take_while(|ch| *ch == first).count();
+    if fence_len < 3 {
+        return None;
+    }
+
+    let info = trimmed[fence_len..].trim();
+    let lang = info
+        .strip_prefix('{')
+        .and_then(|inner| inner.strip_suffix('}'))
+        .unwrap_or(info)
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .find(|part| !part.is_empty())
+        .unwrap_or_default();
+
+    Some((first, fence_len, lang))
+}
+
+fn is_fence_close(line: &str, fence_char: char, fence_len: usize) -> bool {
+    let trimmed = line.trim();
+    let run = trimmed.chars().take_while(|ch| *ch == fence_char).count();
+    run >= fence_len && trimmed.chars().skip(run).all(char::is_whitespace)
 }
 
 fn comrak_options<'a>() -> options::Options<'a> {
@@ -160,4 +241,28 @@ fn comrak_options<'a>() -> options::Options<'a> {
     options.render.r#unsafe = true;
 
     options
+}
+
+#[cfg(test)]
+mod tests {
+    use super::md_to_html;
+    use crate::config::Theme;
+
+    #[test]
+    fn md_to_html_renders_mermaid_fence_as_svg() {
+        let md = "```mermaid\ngraph TD\nA-->B\n```";
+        let html = md_to_html(md, &Theme::Github, false);
+
+        assert!(html.contains("<svg"));
+        assert!(!html.contains("language-mermaid"));
+    }
+
+    #[test]
+    fn md_to_html_keeps_non_mermaid_fence_untouched() {
+        let md = "```rust\nfn main() {}\n```";
+        let html = md_to_html(md, &Theme::Github, false);
+
+        assert!(html.contains("language-rust"));
+        assert!(!html.contains("<div class=\"mcat-mermaid\">"));
+    }
 }

--- a/crates/core/src/markdown_viewer/mod.rs
+++ b/crates/core/src/markdown_viewer/mod.rs
@@ -5,7 +5,10 @@ pub mod utils;
 
 use crate::{markdown_viewer::render::build_toc, themes::CustomTheme};
 use comrak::{
-    Arena, markdown_to_html_with_plugins, options, plugins::syntect::SyntectAdapterBuilder,
+    Arena, format_html_with_plugins,
+    nodes::{AstNode, NodeHtmlBlock, NodeValue},
+    options,
+    plugins::syntect::SyntectAdapterBuilder,
 };
 use image_preprocessor::ImagePreprocessor;
 use itertools::Itertools;
@@ -93,7 +96,9 @@ pub fn md_to_ansi(
 pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
     let options = comrak_options();
 
-    let markdown = preprocess_mermaid_fences(markdown, theme);
+    let arena = Arena::new();
+    let root = comrak::parse_document(&arena, markdown, &options);
+    mutate_mermaid_blocks(root, theme);
 
     let theme = CustomTheme::from(theme);
     let mut theme_set = ThemeSet::load_defaults();
@@ -114,7 +119,8 @@ pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
         false => None,
     };
 
-    let html = markdown_to_html_with_plugins(&markdown, &options, &plugins);
+    let mut html = String::new();
+    format_html_with_plugins(root, &options, &mut html, &plugins).unwrap();
     match full_css {
         Some(css) => format!(
             r#"
@@ -135,83 +141,37 @@ pub fn md_to_html(markdown: &str, theme: &Theme, style: bool) -> String {
     }
 }
 
-fn preprocess_mermaid_fences(markdown: &str, theme: &Theme) -> String {
-    let mut out = Vec::new();
-    let mut iter = markdown.lines();
-
-    while let Some(line) = iter.next() {
-        if let Some((fence_char, fence_len, lang)) = parse_fence_open(line)
-            && matches!(lang, "mermaid" | "mmd")
-        {
-            let mut body = Vec::new();
-            let mut closed = false;
-
-            for next_line in iter.by_ref() {
-                if is_fence_close(next_line, fence_char, fence_len) {
-                    closed = true;
-                    break;
+fn mutate_mermaid_blocks<'a>(root: &'a AstNode<'a>, theme: &Theme) {
+    for node in root.descendants() {
+        let literal = {
+            let data = node.data.borrow();
+            if let NodeValue::CodeBlock(ref block) = data.value {
+                if matches!(block.info.as_str(), "mermaid" | "mmd") {
+                    Some(block.literal.clone())
+                } else {
+                    None
                 }
-                body.push(next_line);
+            } else {
+                None
             }
+        };
 
-            if closed {
-                let source = body.join("\n");
-                if let Some(svg) = render_mermaid_svg(&source, theme) {
-                    out.push("<div class=\"mcat-mermaid\">".to_owned());
-                    out.push(svg);
-                    out.push("</div>".to_owned());
-                    continue;
-                }
+        if let Some(source) = literal {
+            if let Some(svg) = render_mermaid_svg(&source, theme) {
+                let html = format!("<div class=\"mcat-mermaid\">\n{}\n</div>\n", svg.trim_end());
+                node.data.borrow_mut().value = NodeValue::HtmlBlock(NodeHtmlBlock {
+                    block_type: 6, // `block_type` follows CommonMark HTML block type 6 semantics; comrak renderers ignore it here since we are mutating post-parse.
+                    literal: html,
+                });
             }
-
-            out.push(line.to_owned());
-            out.extend(body.into_iter().map(ToOwned::to_owned));
-            if closed {
-                out.push(std::iter::repeat_n(fence_char, fence_len).collect());
-            }
-            continue;
         }
-
-        out.push(line.to_owned());
     }
-
-    out.join("\n")
 }
 
 fn render_mermaid_svg(source: &str, theme: &Theme) -> Option<String> {
     let mut opts = mermaid_rs_renderer::RenderOptions::modern();
     opts.theme = theme.to_custom().to_mermaid_theme();
     mermaid_rs_renderer::render_with_options(source, opts).ok()
-}
-
-fn parse_fence_open(line: &str) -> Option<(char, usize, &str)> {
-    let trimmed = line.trim_start();
-    let first = trimmed.chars().next()?;
-    if first != '`' && first != '~' {
-        return None;
-    }
-
-    let fence_len = trimmed.chars().take_while(|ch| *ch == first).count();
-    if fence_len < 3 {
-        return None;
-    }
-
-    let info = trimmed[fence_len..].trim();
-    let lang = info
-        .strip_prefix('{')
-        .and_then(|inner| inner.strip_suffix('}'))
-        .unwrap_or(info)
-        .split(|c: char| c == ',' || c.is_whitespace())
-        .find(|part| !part.is_empty())
-        .unwrap_or_default();
-
-    Some((first, fence_len, lang))
-}
-
-fn is_fence_close(line: &str, fence_char: char, fence_len: usize) -> bool {
-    let trimmed = line.trim();
-    let run = trimmed.chars().take_while(|ch| *ch == fence_char).count();
-    run >= fence_len && trimmed.chars().skip(run).all(char::is_whitespace)
 }
 
 fn comrak_options<'a>() -> options::Options<'a> {

--- a/crates/core/tests/output.rs
+++ b/crates/core/tests/output.rs
@@ -30,6 +30,19 @@ fn stdin_md_output_is_html() {
         .stdout(predicate::str::contains("Header"));
 }
 
+    #[test]
+    fn stdin_md_mermaid_output_html_contains_svg() {
+        Command::cargo_bin("mcat")
+        .unwrap()
+        .arg("--output")
+        .arg("html")
+        .write_stdin("```mermaid\ngraph TD\nA-->B\n```")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("<svg"))
+        .stdout(predicate::str::contains("mcat-mermaid"));
+    }
+
 #[test]
 fn stdin_svg_output_is_image() {
     let svg = r#"<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>"#;

--- a/crates/rasteroid/src/image_extended.rs
+++ b/crates/rasteroid/src/image_extended.rs
@@ -266,28 +266,9 @@ impl ZoomPanViewport {
     }
 
     fn clamp_pan(&mut self) {
-        let scale_x = self.container_width as f32 / self.image_width as f32;
-        let scale_y = self.container_height as f32 / self.image_height as f32;
-        let base_scale = scale_x.min(scale_y);
-        let scale_factor = base_scale * self.zoom as f32;
-
-        let viewport_width = (self.container_width as f32 / scale_factor) as u32;
-        let viewport_height = (self.container_height as f32 / scale_factor) as u32;
-
-        let max_pan_x = (self.image_width - viewport_width) as f32 / 2.0;
-        let max_pan_y = (self.image_height - viewport_height) as f32 / 2.0;
-
-        if viewport_width >= self.image_width {
-            self.pan_x = 0;
-        } else {
-            self.pan_x = self.pan_x.max(-(max_pan_x as i32)).min(max_pan_x as i32);
-        }
-
-        if viewport_height >= self.image_height {
-            self.pan_y = 0;
-        } else {
-            self.pan_y = self.pan_y.max(-(max_pan_y as i32)).min(max_pan_y as i32);
-        }
+        let (min_pan_x, max_pan_x, min_pan_y, max_pan_y) = self.get_pan_limits();
+        self.pan_x = self.pan_x.clamp(min_pan_x, max_pan_x);
+        self.pan_y = self.pan_y.clamp(min_pan_y, max_pan_y);
     }
 
     /// get the current zoom level
@@ -358,5 +339,31 @@ pub fn calc_fit(src_width: u32, src_height: u32, dst_width: u32, dst_height: u32
         // Image is taller than target: scale by height
         let scaled_width = (dst_height as f32 * src_ar).round() as u32;
         (scaled_width, dst_height)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ZoomPanViewport;
+
+    #[test]
+    fn clamp_pan_handles_container_larger_than_image() {
+        let mut vp = ZoomPanViewport::new(320, 160, 100, 50);
+        vp.set_pan(999, -999);
+
+        assert_eq!(vp.pan_x(), 0);
+        assert_eq!(vp.pan_y(), 0);
+    }
+
+    #[test]
+    fn set_zoom_is_safe_at_min_zoom_with_large_viewport() {
+        let mut vp = ZoomPanViewport::new(320, 160, 100, 50);
+        vp.set_zoom(1);
+
+        let view = vp.get_viewport();
+        assert_eq!(view.width, 100);
+        assert_eq!(view.height, 50);
+        assert_eq!(view.x, 0);
+        assert_eq!(view.y, 0);
     }
 }


### PR DESCRIPTION
## Summary

Three bugs fixed in the interactive viewer path:

### 1. Mermaid fences not rendered with `-I`
`md_to_html()` (used for the HTML→screenshot path) had no Mermaid preprocessing.
Added `preprocess_mermaid_fences()` which converts ```mermaid``` fences to inline SVG via `mermaid_rs_renderer` before Comrak parses the Markdown.

### 2. Panic on zoom-in (`=` key) — unsigned underflow
`clamp_pan()` subtracted `viewport_width` from `image_width` using `u32` arithmetic without guarding against the case where the viewport is wider than the image, causing an overflow panic. Fixed by delegating to `get_pan_limits()` which already has the guard.

### 3. HJKL navigation stutter
Rendering was gated on a 50 ms throttle check evaluated only when a key was pressed. If a key arrived during the throttle window the state changed but no redraw fired until the next keypress, causing visible stutters. Fixed by introducing a `needs_redraw` dirty flag; the render tick fires at ~60 fps whenever dirty, decoupled from key events.

## Tests
- 2 unit tests in `markdown_viewer::tests` (mermaid SVG present, non-mermaid fence untouched)
- 1 integration test in `crates/core/tests/output.rs` (HTML output contains `<svg` and `mcat-mermaid`)
- 2 regression tests in `rasteroid::image_extended::tests` (underflow-safe pan clamp)